### PR TITLE
use NeatJSON with ruby and Opalrb (Hotfix/immutable strings)

### DIFF
--- a/javascript/neatjson.html
+++ b/javascript/neatjson.html
@@ -96,7 +96,9 @@
 			else{
 				var parts=[];
 				for (var k in opts) parts.push('<b>'+k+'<\/b>:'+JSON.stringify(opts[k]));
-				commandText = "neatJSON(obj,{ "+parts.join(', ')+" })";
+				optionsString = "{ "+parts.join(', ')+" })"
+				commandText = "neatJSON(obj, " + optionsString;
+				commandTextRuby = "JSON.neat_generate(obj, "+ optionsString.replace( /([a-z])([A-Z0-9])/g, "$1_$2").toLowerCase();
 			}
 			if (commandText==lastCommand && inp.value==lastInput) return;
 			lastCommand = commandText;
@@ -107,7 +109,9 @@
 			out.innerHTML = neatJSON(obj,opts).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 			var elapsed = new Date-start;
 			console.log(commandText.replace(/<\/?b>/g,'')+" took "+elapsed+"ms");
-			code.innerHTML = "var json = "+commandText+"; <i>// took ~"+elapsed+"ms<\/i>";
+
+			code.innerHTML = "var json = "+commandText+"; <i>// took ~"+elapsed+"ms<\/i>" +
+					         "<br/>json = " + commandTextRuby + " <i># took ~"+elapsed+"ms<\/i>";
 		}catch(e){
 			out.innerHTML = e;
 		}

--- a/lib/neatjson.rb
+++ b/lib/neatjson.rb
@@ -98,7 +98,7 @@ module JSON
 							keyvals[0][0].sub! "#{indent} ", "#{indent}{"
 							if opts[:aligned]
 								longest = keyvals.map(&:first).map(&:length).max
-								keyvals.each{ |k,v| k.replace( "%-#{longest}s" % k ) }
+                keyvals = keyvals.map{|k, v| ["%-#{longest}s" % k, v] }
 							end
 							keyvals.map! do |k,v|
 								indent2 = " "*"#{k}#{colonn}".length
@@ -115,7 +115,7 @@ module JSON
 							keyvals = keyvals.sort_by(&:first) if opts[:sorted]
 							if opts[:aligned]
 								longest = keyvals.map(&:first).map(&:length).max
-								keyvals.each{ |k,v| k.replace( "%-#{longest}s" % k ) }
+                keyvals = keyvals.map{|k, v| ["%-#{longest}s" % k, v] }
 							end
 							indent2 = "#{indent}#{opts[:indent]}"
 							keyvals.map! do |k,v|

--- a/lib/neatjson.rb
+++ b/lib/neatjson.rb
@@ -67,7 +67,6 @@ module JSON
 					end
 
 				when Array
-					return "#{indent}[]" if o.empty?
 					pieces = o.map{ |v| build[v,''] }
 					one_line = "#{indent}[#{apad}#{pieces.join comma}#{apad}]"
 					if !opts[:wrap] || (one_line.length <= opts[:wrap])
@@ -84,7 +83,6 @@ module JSON
 					end
 
 				when Hash
-					return "#{indent}{}" if o.empty?
 					keyvals = o.map{ |k,v| [ k.to_s.inspect, build[v,''] ] }
 					keyvals = keyvals.sort_by(&:first) if opts[:sorted]
 					keyvals = keyvals.map{ |kv| kv.join(colon1) }.join(comma)

--- a/lib/neatjson.rb
+++ b/lib/neatjson.rb
@@ -67,9 +67,12 @@ module JSON
 					end
 
 				when Array
+					return "#{indent}[]" if o.empty?
 					pieces = o.map{ |v| build[v,''] }
 					one_line = "#{indent}[#{apad}#{pieces.join comma}#{apad}]"
-					if !opts[:wrap] || (one_line.length <= opts[:wrap])
+					if o.empty?
+						"#{indent}[]" if o.empty?
+					elsif !opts[:wrap] || (one_line.length <= opts[:wrap])
 						one_line
 					elsif opts[:short]
 						indent2 = "#{indent} #{apad}"
@@ -83,11 +86,14 @@ module JSON
 					end
 
 				when Hash
+					return "#{indent}{}" if o.empty?
 					keyvals = o.map{ |k,v| [ k.to_s.inspect, build[v,''] ] }
 					keyvals = keyvals.sort_by(&:first) if opts[:sorted]
 					keyvals = keyvals.map{ |kv| kv.join(colon1) }.join(comma)
 					one_line = "#{indent}{#{opad}#{keyvals}#{opad}}"
-					if !opts[:wrap] || (one_line.length <= opts[:wrap])
+					if o.empty?
+						"#{indent}{}" if o.empty?
+					elsif !opts[:wrap] || (one_line.length <= opts[:wrap])
 						one_line
 					else
 						if opts[:short]


### PR DESCRIPTION
I wanted to use neatJson in https://github.com/opal/opal. Of course I could have build a wrapper around the JS version, but I wanted it to use it with ruby objects.

So I had to replace the usage of mutable string by another map operation. I am not sure if it is a performance issue on large JSON objects ...

thereby I also changed neatjson.html to additionally expose the ruby version of the options.

also provide a fix for #12


Thanks for the great JSON formatter.



