### PR TITLE
Feature/opal support

### DIFF
--- a/lib/neatjson.rb
+++ b/lib/neatjson.rb
@@ -78,8 +78,8 @@ module JSON
 						elsif opts[:short]
 							indent2 = "#{indent} #{apad}"
 							pieces = o.map{ |v| build[ v,indent2 ] }
-							pieces[0].sub! indent2, "#{indent}[#{apad}"
-							pieces.last << apad << "]"
+							pieces[0] = pieces[0].sub indent2, "#{indent}[#{apad}"
+							pieces[pieces.count - 1 ] =  pieces.last + apad + "]"
 							pieces.join ",\n"
 						else
 							indent2 = "#{indent}#{opts[:indent]}"
@@ -101,10 +101,11 @@ module JSON
 							if opts[:short]
 								keyvals = o.map{ |k,v| ["#{indent} #{opad}#{k.to_s.inspect}",v] }
 								keyvals = keyvals.sort_by(&:first) if opts[:sorted]
-								keyvals[0][0].sub! "#{indent} ", "#{indent}{"
+								keyvals[0][0] = keyvals[0][0].sub "#{indent} ", "#{indent}{"
 								if opts[:aligned]
 									longest = keyvals.map(&:first).map(&:length).max
-									keyvals.each{ |k,v| k.replace( "%-#{longest}s" % k ) }
+									#keyvals.each{ |k,v| k.replace( "%-#{longest}s" % k ) }
+									keyvals = keyvals.inject({}){|r, e| r["%-#{longest}s" % e.first] = e.last; r}
 								end
 								keyvals.map! do |k,v|
 									indent2 = " "*"#{k}#{colonn}".length
@@ -115,16 +116,17 @@ module JSON
 										one_line
 									end
 								end
-								keyvals.join(",\n") << opad << "}"
+								keyvals.join(",\n") + opad + "}"
 							else
 								keyvals = o.map{ |k,v| ["#{indent}#{opts[:indent]}#{k.to_s.inspect}",v] }
 								keyvals = keyvals.sort_by(&:first) if opts[:sorted]
 								if opts[:aligned]
 									longest = keyvals.map(&:first).map(&:length).max
-									keyvals.each{ |k,v| k.replace( "%-#{longest}s" % k ) }
+									#keyvals.each{ |k,v| k.replace( "%-#{longest}s" % k ) }
+									keyvals = keyvals.inject({}){|r, e| r["%-#{longest}s" % e.first] = e.last; r}
 								end
 								indent2 = "#{indent}#{opts[:indent]}"
-								keyvals.map! do |k,v|
+								keyvals = keyvals.map do |k,v|
 									one_line = "#{k}#{colonn}#{build[v,'']}"
 									if opts[:wrap] && (one_line.length > opts[:wrap]) && (v.is_a?(Array) || v.is_a?(Hash))
 										"#{k}#{colonn}#{build[v,indent2].lstrip}"

--- a/test/test_neatjson-opal.rb
+++ b/test/test_neatjson-opal.rb
@@ -1,0 +1,225 @@
+require_relative 'neatjson'
+
+TESTS = [
+		{value:true,  tests:[{json:"true"  }]},
+		{value:false, tests:[{json:"false" }]},
+		{value:nil,   tests:[{json:"null"  }]},
+		{value:5,     tests:[
+				{json:"5"},
+				{json:"5", opts:{decimals:3}},
+		]},
+		{value:5.0, tests:[
+				{json:"5"},
+				{json:"5", opts:{decimals:3}},
+		]},
+		{value:5.0001, tests:[
+				{json:"5.0001"},
+				{json:"5.000", opts:{decimals:3}},
+		]},
+		{value:4.2, tests:[
+				{json:"4.2"},
+				{json:"4",   opts:{decimals:0}},
+				{json:"4.20",opts:{decimals:2}},
+		]},
+		{value:4.199, tests:[{json:"4.20", opts:{decimals:2}}]},
+		{value:4.204, tests:[{json:"4.20", opts:{decimals:2}}]},
+		{value:-1.9,  tests:[{json:"-2",   opts:{decimals:0}}]},
+		{value:-2.4,  tests:[{json:"-2",   opts:{decimals:0}}]},
+		{value:1e23,  tests:[{json:/1(?:\.0+)?e\+23/i}]},
+		{value:1e-9,  tests:[{json:/1(?:\.0+)?e-0*9/i}]},
+		{value:-2.4,  tests:[{json:"-2",   opts:{decimals:0}}]},
+
+		{value:"foo",       tests:[{json:"\"foo\""}]},
+		{value: :foo,       tests:[{json:"\"foo\""}]},
+		{value:"foo\nbar",  tests:[{json:"\"foo\\nbar\""}]},
+
+		{value:[1,2,3,4,[5,6,7,[8,9,10],11,12]], tests:[
+				{ json:"[1,2,3,4,[5,6,7,[8,9,10],11,12]]" },
+				{ json:"[\n  1,\n  2,\n  3,\n  4,\n  [5,6,7,[8,9,10],11,12]\n]", opts:{wrap:30} },
+				{ json:"[\n  1,\n  2,\n  3,\n  4,\n  [\n    5,\n    6,\n    7,\n    [8,9,10],\n    11,\n    12\n  ]\n]", opts:{wrap:20} },
+				{ json:"[\n  1,\n  2,\n  3,\n  4,\n  [\n    5,\n    6,\n    7,\n    [\n      8,\n      9,\n      10\n    ],\n    11,\n    12\n  ]\n]", opts:{wrap:true} },
+				{ json:"[\n\t1,\n\t2,\n\t3,\n\t4,\n\t[\n\t\t5,\n\t\t6,\n\t\t7,\n\t\t[\n\t\t\t8,\n\t\t\t9,\n\t\t\t10\n\t\t],\n\t\t11,\n\t\t12\n\t]\n]", opts:{wrap:true,indent:"\t"} },
+				{ json:"[1,2,3,4,[5,6,7,[8,9,10],11,12]]", opts:{array_padding:0} },
+				{ json:"[ 1,2,3,4,[ 5,6,7,[ 8,9,10 ],11,12 ] ]", opts:{array_padding:1} },
+				{ json:"[  1,2,3,4,[  5,6,7,[  8,9,10  ],11,12  ]  ]", opts:{array_padding:2} },
+				{ json:"[1, 2, 3, 4, [5, 6, 7, [8, 9, 10], 11, 12]]", opts:{after_comma:1} },
+				{ json:"[ 1, 2, 3, 4, [ 5, 6, 7, [ 8, 9, 10 ], 11, 12 ] ]", opts:{after_comma:1,array_padding:1} },
+				{ json:"[1,\n 2,\n 3,\n 4,\n [5,\n  6,\n  7,\n  [8,\n   9,\n   10],\n  11,\n  12]]", opts:{short:true,wrap:true} },
+				{ json:"[1,\n 2,\n 3,\n 4,\n [5,\n  6,\n  7,\n  [8,\n   9,\n   10],\n  11,\n  12]]", opts:{short:true,wrap:true,after_comma:1} },
+				{ json:"[ 1,\n  2,\n  3,\n  4,\n  [ 5,\n    6,\n    7,\n    [ 8,\n      9,\n      10 ],\n    11,\n    12 ] ]", opts:{short:true,wrap:true,array_padding:1} },
+		]},
+
+		{value:[1,2,3], tests:[
+				{ json:"[1,2,3]" },
+				{ json:"[1 ,2 ,3]",   opts:{before_comma:1} },
+				{ json:"[1 , 2 , 3]", opts:{around_comma:1} },
+		]},
+
+		{value:{b:1,a:2}, tests:[
+				{ json:'{"b":1,"a":2}' },
+				{ json:'{"a":2,"b":1}',                   opts:{sorted:true} },
+				{ json:'{"a":2, "b":1}',                  opts:{sorted:true,after_comma:1} },
+				{ json:'{"a" :2,"b" :1}',                 opts:{sorted:true,before_colon:1} },
+				{ json:'{"a": 2,"b": 1}',                 opts:{sorted:true,after_colon:1} },
+				{ json:'{"a" : 2,"b" : 1}',               opts:{sorted:true,before_colon:1,after_colon:1} },
+				{ json:'{"a" : 2, "b" : 1}',              opts:{sorted:true,before_colon:1,after_colon:1,after_comma:1} },
+				{ json:'{ "a" : 2, "b" : 1 }',            opts:{sorted:true,before_colon:1,after_colon:1,after_comma:1,padding:1} },
+				{ json:'{ "a" : 2, "b" : 1 }',            opts:{sorted:true,around_colon:1,after_comma:1,object_padding:1} },
+				{ json:'{"a" : 2, "b" : 1}',              opts:{sorted:true,before_colon:1,after_colon:1,after_comma:1,array_padding:1} },
+				{ json:'{  "a"  :  2, "b"  :  1  }',      opts:{sorted:true,around_colon:2,after_comma:1,padding:2} },
+				{ json:'{  "a":2, "b":1  }',              opts:{sorted:true,after_comma:1,padding:2} },
+				{ json:'{"b":  1,"a":  2}',               opts:{after_colon_1:2} },
+				{ json:'{"b"  :  1,"a"  :  2}',           opts:{around_colon_1:2} },
+				{ json:"{\n  \"b\":1,\n  \"a\":2\n}",     opts:{wrap:true,around_colon_1:2} },
+				{ json:"{\n  \"b\": 1,\n  \"a\": 2\n}",   opts:{wrap:true,after_colon:1} },
+				{ json:"{\n  \"b\": 1,\n  \"a\": 2\n}",   opts:{wrap:true,after_colon_n:1} },
+				{ json:"{\"b\":1,\n \"a\":2}",            opts:{wrap:true,short:true} },
+				{ json:"{\"b\": 1,\n \"a\": 2}",          opts:{wrap:true,short:true,after_colon:1} },
+				{ json:"{\"b\": 1,\n \"a\": 2}",          opts:{wrap:true,short:true,after_colon_n:1} },
+				{ json:"{\"b\":1,\n \"a\":2}",            opts:{wrap:true,short:true,after_colon_1:1} },
+		]},
+
+		{value:{b:1,aaa:2,cc:3}, tests:[
+				{ json:"{\n  \"b\":1,\n  \"aaa\":2,\n  \"cc\":3\n}",    opts:{wrap:true} },
+				{ json:"{\n  \"b\"  :1,\n  \"aaa\":2,\n  \"cc\" :3\n}", opts:{wrap:true,aligned:true} },
+				{ json:"{\"b\":1,\"aaa\":2,\"cc\":3}",                  opts:{aligned:true} },
+				{ json:"{\n  \"aaa\":2,\n  \"b\"  :1,\n  \"cc\" :3\n}", opts:{wrap:true,aligned:true,sorted:true} },
+		]},
+
+		{value:{a:1}, tests:[
+				{ json:'{"a":1}' },
+				{ json:"{\n  \"a\":1\n}",   opts:{wrap:true} },
+				{ json:"{\n  \"a\":1\n  }", opts:{wrap:true, indent_last:true} },
+				{ json:"{\n \"a\":1\n }",   opts:{wrap:true, indent:" ", indent_last:true} },
+		]},
+
+		{value:{ b:17, a:42 }, tests:[
+				{ json:"{\"a\":42,\n \"b\":17}", opts:{wrap:10,sorted:true,short:true} },
+		]},
+
+		{value:[1,{a:2},3], tests:[
+				{ json:'[1,{"a":2},3]' },
+				{ json:'[ 1,{ "a":2 },3 ]',                       opts:{padding:1} },
+				{ json:'[ 1, { "a":2 }, 3 ]',                     opts:{padding:1,after_comma:1} },
+				{ json:"[\n  1,\n  {\n    \"a\":2\n  },\n  3\n]", opts:{wrap:true} },
+				{ json:"[\n  1,\n  {\"a\":2},\n  3\n]",           opts:{wrap:10} },
+				{ json:"[\n  1,\n  {\n    \"a\":2\n    },\n  3\n  ]", opts:{wrap:true,indent_last:true} },
+		]},
+
+		{value:[1,{a:2,b:3},4], tests:[
+				{ json:"[1,\n {\"a\":2,\n  \"b\":3},\n 4]", opts:{wrap:0,short:true} },
+		]},
+
+		{value:{a:1,b:[2,3,4],c:3}, tests:[
+				{ json:'{"a":1,"b":[2,3,4],"c":3}' },
+				{ json:"{\n  \"a\":1,\n  \"b\":[2,3,4],\n  \"c\":3\n}",                           opts:{wrap:10} },
+				{ json:"{\n  \"a\":1,\n  \"b\":[\n    2,\n    3,\n    4\n  ],\n  \"c\":3\n}",     opts:{wrap:true} },
+				{ json:"{\n  \"a\":1,\n  \"b\":[\n    2,\n    3,\n    4\n    ],\n  \"c\":3\n  }", opts:{wrap:true,indent_last:true} },
+		]},
+
+		{value:{hooo:42,whee:['yaaa','oooo','booy'],zoop:"whoop"}, tests:[
+				{ json:"{\"hooo\":42,\n \"whee\":[\"yaaa\",\n         \"oooo\",\n         \"booy\"],\n \"zoop\":\"whoop\"}", opts:{wrap:20,short:true} },
+		]},
+
+		{value:{ a:[ {x:"foo",y:"jim"}, {x:"bar",y:"jam"} ] }, tests:[
+				{ json:"{\"a\":[{\"x\":\"foo\",\n       \"y\":\"jim\"},\n      {\"x\":\"bar\",\n       \"y\":\"jam\"}]}", opts:{wrap:true,short:true} },
+		]},
+
+		{value:{"abcdefghij"=>[{"abcdefghijklmnop"=>{}}]}, tests:[
+				{ json:"{\"abcdefghij\":[{\"abcdefghijklmnop\":{}}]}" },
+				{ json:"{\"abcdefghij\" : [{\"abcdefghijklmnop\" : {}}]}", opts:{wrap:1, short:true, around_colon_n:1} },
+		]},
+
+		{value:{foo:{}}, tests:[
+				{ json:"{\"foo\":{}}" },
+				{ json:"{\"foo\":{}}",        opts:{wrap:false} },
+				{ json:"{\n  \"foo\":{}\n}",  opts:{wrap:5}    },
+				{ json:"{\"foo\":{}}",        opts:{wrap:1, short:true} },
+		]},
+
+		{value:["foo",{},"bar"], tests:[
+				{ json:"[\n  \"foo\",\n  {},\n  \"bar\"\n]",  opts:{wrap:1} },
+				{ json:"[\"foo\",\n {},\n \"bar\"]",          opts:{wrap:1, short:true} },
+		]},
+
+		{value:["foo",[],"bar"], tests:[
+				{ json:"[\n  \"foo\",\n  [],\n  \"bar\"\n]",  opts:{wrap:1} },
+				{ json:"[\"foo\",\n [],\n \"bar\"]",          opts:{wrap:1, short:true} },
+		]},
+
+		{value:["foo",[{},[{foo:[]},42]],"bar"], tests:[
+				{ json:"[\"foo\",\n [{},\n  [{\"foo\":[]},\n   42]],\n \"bar\"]",  opts:{wrap:1, short:true} },
+		]},
+
+		{value:Class.new{ def to_json(*a); {a:1}.to_json(*a); end }.new, tests:[
+				{ json:'{"a":1}' },
+				{ json:'{"a":1}', opts:{wrap:true} },
+				{ json:'{"a":1}',   opts:{indent:''} },
+		]},
+
+		{value:Class.new{ def to_json(*a); JSON.neat_generate({a:1},*a); end }.new, tests:[
+				{ json:'{"a":1}' },
+				{ json:"{\n  \"a\":1\n}", opts:{wrap: true} },
+		]},
+
+		{value:{a:{b:{c:{d:{e:{f:{g:{h:{i:{j:{k:{l:{m:1}}}}}}}}}}}}}, tests:[
+				{ json:'{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":{"i":{"j":{"k":{"l":{"m":1}}}}}}}}}}}}}', opts:{wrap:false} },
+				{ json:'{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":{"i":{"j":{"k":{"l":{"m":1}}}}}}}}}}}}}', opts:{wrap:1,short:true} },
+				{ json:"{\n  \"a\":{\n    \"b\":{\n      \"c\":{\n        \"d\":{\n          \"e\":{\n            \"f\":{\n              \"g\":{\n                \"h\":{\n                  \"i\":{\n                    \"j\":{\n                      \"k\":{\n                        \"l\":{\n                          \"m\":1\n                        }\n                      }\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}", opts:{wrap:1} },
+		]},
+
+
+
+
+
+
+
+# ,
+#
+# 		{value:{a:1, b:2, c:{a:1, b:2}, d: 3, e:4}, tests:[
+# 				{ json:%Q{{"e":4,"d":3,"c":{"b":2,"a":1},"b":2,"a":1}}, opts:{wrap:false, explicit_sort: [[:e, :d,],[:b, :a]]} },
+# 				{ json:%Q{{"e":4,"d":3,"b":2,"a":1,"c":{"b":2,"a":1}}}, opts:{wrap:false, explicit_sort: [[:e, :d,],[:b, :a, :c]]} },
+# 				{ json:%Q{{
+#   "a":1,
+#   "b":2,
+#   "c":{
+#     "a":1,
+#     "b":2
+#   },
+#   "d":3,
+#   "e":4
+# }}, opts:{wrap:1, explicit_sort: [[:e, :d,],[:b, :a]]} },
+# 				{ json:%Q{{
+#   "a":1,
+#   "b":2,
+#   "c":{
+#     "a":1,
+#     "b":2
+#   },
+#   "d":3,
+#   "e":4
+# }}, opts:{wrap:1, explicit_sort: [[:e, :d,],[:b, :a, :c]]} }
+# 		]}
+
+]
+
+start = Time.now
+pass  = 0
+count = 0
+TESTS.each do |value_tests|
+	val, tests = value_tests[:value], value_tests[:tests]
+	tests.each do |test|
+		cmd = test[:opts] ? "JSON.neat_generate(#{val.inspect},#{test[:opts].inspect})" : "JSON.neat_generate(#{val.inspect})"
+		begin
+			json = test[:opts] ? JSON.neat_generate(val,test[:opts].dup) : JSON.neat_generate(val)
+			raise "EXPECTED:\n#{test[:json]}\nACTUAL:\n#{json}" unless test[:json]===json
+			pass += 1
+		rescue StandardError => e
+			puts "Error running #{cmd}", e, ""
+		end
+		count += 1
+	end
+end
+elapsed = Time.now-start
+elapsed = 0.0001 if elapsed==0
+puts "%d/%d test#{:s if count!=1} passed in %.2fms (%d tests per second)" % [pass, count, elapsed*1000, count/elapsed]


### PR DESCRIPTION
I took your latest master branch and made the tests with Opal. There is still the issue that opal does not support mutable strings (it is a transpiler to javascript which lacks this support).

I changed the immutable string issues and now all tests pass if run through opal. There was also a difference when handling arbitrary classes. to_json behaves slightly different between ruby and opal with respect of options and indentation.

I never used mutable strings in ruby so all my ruby code worked well with Opal.

This PR replaces PR #13. I would really appreciate if you could consicer merge this.  
